### PR TITLE
修复BugFix: Add UTF-8 meta tag to prevent character encoding issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>汇率转换器</title>
     <meta
       name="viewport"


### PR DESCRIPTION
Added `<meta charset="UTF-8">` to `index.html` to ensure proper display of all characters, including Chinese, by explicitly setting the character encoding for the browser.